### PR TITLE
Feat/refactoring

### DIFF
--- a/display.c
+++ b/display.c
@@ -8,8 +8,9 @@
 #include <limits.h>
 #include "display.h"
 #include "file.h"
+#include "gui.h"
 
-void display_error(WINDOW *menu_win, const char *format, ...) {
+void display_error(const char *format, ...) {
 
     static int error_displaying = 0;  
     if (error_displaying) return;
@@ -51,13 +52,13 @@ void display_files(WINDOW *win, char *files[], int file_count, int highlight, in
     //공백 배경색 처리
     for(int i=5;i<37;i++)
         mvwprintw(win,1,i," ");
-    mvwprintw(win, 1, 37, "Size"); // Size 위치 조정
+    mvwprintw(win, 1, 31, "Size"); // Size 위치 조정
     //공백 배경색 처리
-    for(int i=41;i<getmaxx(win)-20;i++)
+    for(int i=35;i<getmaxx(win)-18;i++)
         mvwprintw(win,1,i," ");
    
-    mvwprintw(win, 1, getmaxx(win) - 20, "Modify time"); // Modify time 위치 오른쪽 정렬
-    for(int i=getmaxx(win)-9;i<getmaxx(win);i++) {
+    mvwprintw(win, 1, getmaxx(win) - 18, "Modify time"); // Modify time 위치 오른쪽 정렬
+    for(int i=getmaxx(win)-7;i<getmaxx(win);i++) {
         mvwprintw(win,1,i," ");
     }
     wattroff(win, COLOR_PAIR(8)); // 헤더 배경색 해제
@@ -105,8 +106,8 @@ void display_ls_file(WINDOW *win, char *files[], int file_count, int highlight, 
 
             // 파일명, 사이즈, 수정 시간 출력 위치 조정
             mvwprintw(win, i + 2, 1, "%-25s", files[index]);                   // 파일 이름
-            mvwprintw(win, i + 2, 32, "%10lld bytes", (long long)file_stat.st_size); // 파일 크기 위치 조정
-            mvwprintw(win, i + 2, getmaxx(win) - 20, "%s", mod_time);             // 수정 시간 오른쪽 끝에 배치
+            mvwprintw(win, i + 2, 22, "%10lld bytes", (long long)file_stat.st_size); // 파일 크기 위치 조정
+            mvwprintw(win, i + 2, getmaxx(win) - 18, "%s", mod_time);             // 수정 시간 오른쪽 끝에 배치
 
             if (index == highlight) {
                 wattroff(win, COLOR_PAIR(7));
@@ -124,8 +125,7 @@ int load_files(char *files[], WINDOW *preview_win) {
 
     dir = opendir(".");
     if (dir == NULL) {
-        mvwprintw(preview_win, 1, 1, "Cannot open current directory.");
-        wrefresh(preview_win);
+        display_error("Cannot open current directory.");
         return -1;
     }
 
@@ -193,7 +193,7 @@ void do_dir(WINDOW *preview_win,const char *filename)
                 }
                 closedir(dir);
             } else {
-                mvwprintw(preview_win, 1, 1, "Cannot opendir: %s", filename);
+                display_error("Cannot opendir: %s", filename);
             }
 }
 
@@ -219,7 +219,8 @@ void do_file(WINDOW *preview_win,const char *filename)
         }
         fclose(file);
     }else {
-        mvwprintw(preview_win, 1, 1, "Cannot open file.");
+
+        display_error( "Cannot open file.");
     }
 }
 
@@ -227,8 +228,7 @@ void more(WINDOW *preview_win, const char *filename)
 {
     FILE *file = fopen(filename, "r");
     if (file == NULL) {
-        mvwprintw(preview_win, 1, 1, "Cannot fopen: %s",filename);
-        wrefresh(preview_win);
+        display_error("Cannot fopen: %s",filename);
         return;
     }
 
@@ -241,8 +241,8 @@ void more(WINDOW *preview_win, const char *filename)
     long prev_offset = 0;   // 이전 오프셋
     FILE *fp_tty = fopen("/dev/tty", "r"); // for 사용자 입력
     if (fp_tty == NULL) {
-        mvwprintw(preview_win, 1, 1, "Cannot open: /dev/tty");
-        wrefresh(preview_win);
+
+        display_error( "Cannot open: /dev/tty");
         fclose(file);
         exit(1);
     }
@@ -312,7 +312,7 @@ int see_more(FILE* file, WINDOW* preview_win, int row, int col)
 void display_path(WINDOW *path_win, WINDOW* preview_win) {
     char cwd[PATH_MAX];
     memset(cwd, 0, PATH_MAX); 
-    get_current_directory(cwd, PATH_MAX, preview_win);
+    get_current_directory(cwd, PATH_MAX);
     werase(path_win);
     box(path_win, 0, 0);
     mvwprintw(path_win, 1, 1, "Current Path: %s", cwd);

--- a/display.c
+++ b/display.c
@@ -52,12 +52,12 @@ void display_files(WINDOW *win, char *files[], int file_count, int highlight, in
     //공백 배경색 처리
     for(int i=5;i<37;i++)
         mvwprintw(win,1,i," ");
-    mvwprintw(win, 1, 31, "Size"); // Size 위치 조정
+    mvwprintw(win, 1, 37, "Size"); // Size 위치 조정
     //공백 배경색 처리
-    for(int i=35;i<getmaxx(win)-18;i++)
+    for(int i=35;i<getmaxx(win)-20;i++)
         mvwprintw(win,1,i," ");
    
-    mvwprintw(win, 1, getmaxx(win) - 18, "Modify time"); // Modify time 위치 오른쪽 정렬
+    mvwprintw(win, 1, getmaxx(win) - 20, "Modify time"); // Modify time 위치 오른쪽 정렬
     for(int i=getmaxx(win)-7;i<getmaxx(win);i++) {
         mvwprintw(win,1,i," ");
     }
@@ -106,9 +106,8 @@ void display_ls_file(WINDOW *win, char *files[], int file_count, int highlight, 
 
             // 파일명, 사이즈, 수정 시간 출력 위치 조정
             mvwprintw(win, i + 2, 1, "%-25s", files[index]);                   // 파일 이름
-            mvwprintw(win, i + 2, 22, "%10lld bytes", (long long)file_stat.st_size); // 파일 크기 위치 조정
-            mvwprintw(win, i + 2, getmaxx(win) - 18, "%s", mod_time);             // 수정 시간 오른쪽 끝에 배치
-
+           mvwprintw(win, i + 2, 32, "%10lld bytes", (long long)file_stat.st_size); // 파일 크기 위치 조정
+            mvwprintw(win, i + 2, getmaxx(win) - 20, "%s", mod_time);             // 수정 시간 오른쪽 끝에 배치
             if (index == highlight) {
                 wattroff(win, COLOR_PAIR(7));
             } else {
@@ -125,7 +124,8 @@ int load_files(char *files[], WINDOW *preview_win) {
 
     dir = opendir(".");
     if (dir == NULL) {
-        display_error("Cannot open current directory.");
+        mvwprintw(preview_win, 1, 1, "Cannot open current directory.");
+        wrefresh(preview_win);
         return -1;
     }
 
@@ -193,7 +193,7 @@ void do_dir(WINDOW *preview_win,const char *filename)
                 }
                 closedir(dir);
             } else {
-                display_error("Cannot opendir: %s", filename);
+                mvwprintw(preview_win, 1, 1, "Cannot opendir: %s", filename);
             }
 }
 
@@ -220,7 +220,7 @@ void do_file(WINDOW *preview_win,const char *filename)
         fclose(file);
     }else {
 
-        display_error( "Cannot open file.");
+        mvwprintw(preview_win, 1, 1, "Cannot open file.");
     }
 }
 
@@ -228,7 +228,8 @@ void more(WINDOW *preview_win, const char *filename)
 {
     FILE *file = fopen(filename, "r");
     if (file == NULL) {
-        display_error("Cannot fopen: %s",filename);
+        mvwprintw(preview_win, 1, 1, "Cannot fopen: %s",filename);
+        wrefresh(preview_win);
         return;
     }
 
@@ -242,7 +243,8 @@ void more(WINDOW *preview_win, const char *filename)
     FILE *fp_tty = fopen("/dev/tty", "r"); // for 사용자 입력
     if (fp_tty == NULL) {
 
-        display_error( "Cannot open: /dev/tty");
+        mvwprintw(preview_win, 1, 1, "Cannot open: /dev/tty");
+        wrefresh(preview_win);
         fclose(file);
         exit(1);
     }

--- a/display.h
+++ b/display.h
@@ -1,11 +1,10 @@
 #ifndef DISPLAY_H
 # define DISPLAY_H
-# include <ncurses.h>
 # define MAX_FILES 1024                  // 최대 파일 수 제한
 # define PANEL_WIDTH (COLS / 2 - 1)      // 좌측 창 넓이
 # define PREVIEW_WIDTH (COLS / 2 - 2)    // 우측 미리보기 창 넓이
 
-
+void display_error(const char *format, ...);
 void display_files(WINDOW *win, char *files[], int file_count, int highlight, int scroll_offset); //from display.c
 int load_files(char *files[],WINDOW* preview_win);  //from display.c
 void display_preview(WINDOW *preview_win, const char *filename); //from display.c

--- a/file.c
+++ b/file.c
@@ -10,18 +10,17 @@
 #include <ncurses.h>
 #include "file.h"
 #include "gui.h"
-
+#include "display.h"
 
 // 파일 또는 디렉터리를 삭제하는 함수
-void remove_file(const char* filepath, WINDOW* preview_win) {
+void remove_file(const char* filepath) {
     struct dirent* entry; 
     struct stat info;
     DIR* dir = opendir(filepath); 
 
     if (dir == NULL) { // 디렉터리가 아니라 파일일 경우, unlink()로 삭제
         if (unlink(filepath) == -1) {
-            mvwprintw(preview_win, 1, 1, "unlink fail %s", filepath);
-            wrefresh(preview_win);
+            display_error("unlink fail %s", filepath);
         }
         return;
     }
@@ -35,18 +34,16 @@ void remove_file(const char* filepath, WINDOW* preview_win) {
 
         snprintf(fullpath, sizeof(fullpath), "%s/%s", filepath, entry->d_name);
 
-        if (stat(fullpath, &info) == -1) { 
-            mvwprintw(preview_win, 1, 1, "stat fail: %s", fullpath);
-            wrefresh(preview_win);
+        if (stat(fullpath, &info) == -1) {
+            display_error("stat fail: %s", filepath);
             continue;
         }
 
         if (S_ISDIR(info.st_mode)) { 
-            remove_file(fullpath, preview_win); // 하위 디렉터리를 재귀적으로 삭제
+            remove_file(fullpath); // 하위 디렉터리를 재귀적으로 삭제
         } else { 
             if (unlink(fullpath) == -1) { 
-                mvwprintw(preview_win, 1, 1, "unlink fail: %s", fullpath);
-                wrefresh(preview_win);
+                display_error("unlink fail: %ss", filepath);
                 continue;
             }
         }
@@ -55,93 +52,51 @@ void remove_file(const char* filepath, WINDOW* preview_win) {
     closedir(dir); // 디렉터리 닫기
 
     if (rmdir(filepath) == -1) { 
-        mvwprintw(preview_win, 1, 1, "rmdir fail: %s", filepath);
-        wrefresh(preview_win);
+        display_error("rmdir fail: %s", filepath);
     }
 }
 
 // 파일 또는 디렉터리를 이동하는 함수
-void move_file(const char* destination, const char* filepath, WINDOW* preview_win) {
+void move_file(const char* destination, const char* filepath) {
     // filepath가 destination의 상위 디렉터리인 경우 수행하지 않음
     size_t parent_len = strlen(filepath);
     if (strncmp(filepath, destination, parent_len) == 0) {
-        mvwprintw(preview_win, 5, 1, "destination이 filepath의 하위 디렉터리입니다.");
-        wrefresh(preview_win);
+        display_error("The destination is a subdirectory of this file path");
         return;
     }
     if (rename(filepath, destination) == -1) {
 
-        display_error(menu_win,"rename fail : %s -> %s (Erorr : %s)",filepath,destination,strerror(errno));
-       // mvwprintw(preview_win, 1, 1, "rename fail: %s -> %s (Error: %s)", filepath, destination, strerror(errno));
-
-        wrefresh(preview_win);
+        display_error("rename fail : %s -> %s (Erorr : %s)",filepath,destination,strerror(errno));
     }
 }
 
-void cp_file(const char* destination, const char* filepath, WINDOW* preview_win) {
-    struct stat src_info, dest_info;
+void cp_file(const char* destination, const char* filepath) {
+    struct stat src_info;
 
     // 원본 파일 상태 확인
     if (stat(filepath, &src_info) == -1) {
-        display_error(menu_win, "stat fail: %s", filepath);
-        wrefresh(preview_win);
+        display_error("stat fail: %s", filepath);
+        return;
+    }
+    
+    size_t parent_len = strlen(filepath);
+    if (strncmp(filepath, destination, parent_len) == 0) {
+        display_error("The destination is a subdirectory of this file path");
         return;
     }
 
-    char real_src[PATH_MAX];
-    char real_dest[PATH_MAX];
-
-    // 원본과 대상의 절대 경로 가져오기
-    if (realpath(filepath, real_src) == NULL) {
-        display_error(menu_win, "Error resolving source path: %s", filepath);
-        wrefresh(preview_win);
-        return;
-    }
-    if (realpath(destination, real_dest) == NULL) {
-        display_error(menu_win, "Error resolving destination path: %s", destination);
-        wrefresh(preview_win);
-        return;
-    }
-
-    // 복사 대상이 원본 디렉터리의 하위 경로인지 확인
-    size_t src_len = strlen(real_src);
-    if (strncmp(real_dest, real_src, src_len) == 0 && real_dest[src_len] == '/') {
-        display_error(menu_win, "Destination is a subdirectory of the source directory.");
-        wrefresh(preview_win);
-        return;
-    }
-
-    // 동일한 파일인지 확인
-    if (strcmp(filepath, destination) == 0) {
-        display_error(menu_win, "Source and destination are the same: %s", filepath);
-        wrefresh(preview_win);
-        return;
-    }
-
-    // 복사 대상에 동일한 파일이 존재하는지 확인
-    if (stat(destination, &dest_info) == 0) {
-        if (S_ISDIR(dest_info.st_mode)) {
-            display_error(menu_win, "Error: Directory already exists at destination");
-        } else {
-            display_error(menu_win, "Error: File already exists at destination");
-        }
-        wrefresh(preview_win);
-        return;
-    }
-
-    // 디렉터리 복사
+    // 복사 로직 시작
     if (S_ISDIR(src_info.st_mode)) {
+        // 디렉터리 복사 로직
         DIR* dir = opendir(filepath);
         if (dir == NULL) {
-            display_error(menu_win, "Cannot open directory: %s", filepath);
-            wrefresh(preview_win);
+            display_error("Cannot open directory: %s", filepath);
             return;
         }
 
         // 복사 대상 디렉터리 생성
-        if (mkdir(destination, src_info.st_mode & 0777) == -1) {
-            display_error(menu_win, "Cannot create directory: %s", destination);
-            wrefresh(preview_win);
+        if (mkdir(destination, src_info.st_mode & 0777) == -1 && errno != EEXIST) {
+            display_error( "Cannot create directory: %s", destination);
             closedir(dir);
             return;
         }
@@ -152,31 +107,25 @@ void cp_file(const char* destination, const char* filepath, WINDOW* preview_win)
                 continue;
             }
 
-            // 하위 디렉터리 및 파일 경로 생성
             char srcPath[PATH_MAX], destPath[PATH_MAX];
             snprintf(srcPath, sizeof(srcPath), "%s/%s", filepath, entry->d_name);
             snprintf(destPath, sizeof(destPath), "%s/%s", destination, entry->d_name);
 
-            cp_file(destPath, srcPath, preview_win); // 하위 파일 및 디렉터리 재귀적으로 복사
+            cp_file(destPath, srcPath);
         }
 
         closedir(dir);
-    } else { // 파일 복사
-        FILE *src, *dest;
-
-        // 원본 파일 열기
-        src = fopen(filepath, "rb");
-        if (src == NULL) {
-            display_error(menu_win, "Cannot open source file: %s", filepath);
-            wrefresh(preview_win);
+    } else {
+        // 일반 파일 복사 로직
+        FILE *src = fopen(filepath, "rb");
+        if (!src) {
+            display_error( "Cannot open source file: %s", filepath);
             return;
         }
 
-        // 대상 파일 열기
-        dest = fopen(destination, "wb");
-        if (dest == NULL) {
-            display_error(menu_win, "Cannot open destination file: %s", destination);
-            wrefresh(preview_win);
+        FILE *dest = fopen(destination, "wb");
+        if (!dest) {
+            display_error("Cannot open destination file: %s", destination);
             fclose(src);
             return;
         }
@@ -194,7 +143,7 @@ void cp_file(const char* destination, const char* filepath, WINDOW* preview_win)
 
 
 
-void get_current_directory(char *buf, size_t size, WINDOW* preview_win) {
+void get_current_directory(char *buf, size_t size) {
     struct stat current_stat, parent_stat, root_stat;
     char temp[PATH_MAX];  // 경로를 저장할 임시 버퍼
     char *ptr = temp + PATH_MAX - 1;  // 버퍼의 끝부터 시작
@@ -209,12 +158,10 @@ void get_current_directory(char *buf, size_t size, WINDOW* preview_win) {
     while (1) {
         // 현재 디렉터리와 상위 디렉터리의 inode 정보를 가져옴
         if (stat(".", &current_stat) != 0) {
-            mvwprintw(preview_win, 1, 1, "Can not stat: current working directory");
-            wrefresh(preview_win);
+            display_error( "Can not stat: current working directory");
         }
         if( stat("..", &parent_stat) != 0){
-            mvwprintw(preview_win, 1, 1, "Can not stat: parent directory");
-            wrefresh(preview_win);
+            display_error("Can not stat: parent directory");
         }
 
         // 루트 디렉터리인지 확인
@@ -225,8 +172,7 @@ void get_current_directory(char *buf, size_t size, WINDOW* preview_win) {
         // 상위 디렉터리로 이동
         DIR *parent = opendir("..");
         if (!parent) {
-            mvwprintw(preview_win, 1, 1, "Can not opendir: parent directory");
-            wrefresh(preview_win);
+            display_error( "Can not opendir: parent directory");
         }
 
         struct dirent *entry;
@@ -262,12 +208,12 @@ void get_current_directory(char *buf, size_t size, WINDOW* preview_win) {
     chdir(buf);
 }
 
-void resolve_absolute_path(char* absolute_path, const char* filename, WINDOW* preview_win) {
+void resolve_absolute_path(char* absolute_path, const char* filename) {
     char current_dir[PATH_MAX-1] = {0};
     char full_path[PATH_MAX] = {0};
 
     // 현재 디렉터리를 구함
-    get_current_directory(current_dir, PATH_MAX, preview_win);
+    get_current_directory(current_dir, PATH_MAX);
 
     // 파일 경로 조합
     snprintf(full_path, sizeof(full_path), "%s/%s", current_dir, filename);
@@ -276,9 +222,8 @@ void resolve_absolute_path(char* absolute_path, const char* filename, WINDOW* pr
     if (access(full_path, F_OK) == 0) {
         strcpy(absolute_path, full_path);
     } else {
-        display_error(menu_win,"File not found : %s",filename);
-        //mvwprintw(preview_win, 1, 2, "File not found: %s\n", filename);
-        wrefresh(preview_win);
+        display_error("File not found : %s",filename);
+        
         absolute_path[0] = '\0';
     }
 }

--- a/file.c
+++ b/file.c
@@ -43,7 +43,7 @@ void remove_file(const char* filepath) {
             remove_file(fullpath); // 하위 디렉터리를 재귀적으로 삭제
         } else { 
             if (unlink(fullpath) == -1) { 
-                display_error("unlink fail: %ss", filepath);
+                display_error("unlink fail: %s", filepath);
                 continue;
             }
         }

--- a/file.h
+++ b/file.h
@@ -1,9 +1,8 @@
 #ifndef FILE_H
 # define FILE_H
-void remove_file(const char* filepath, WINDOW* preview_win);
-void move_file(const char* destination, const char* filepath, WINDOW* preview_win);
-void cp_file(const char* destination, const char* filepath, WINDOW* preview_win);
-void get_current_directory(char *buf, size_t size, WINDOW* preview_win);
-void resolve_absolute_path(char* absolute_path, const char* filename, WINDOW* preview_win);
-void display_error(WINDOW *menu_win, const char *format, ...);
+void remove_file(const char* filepath);
+void move_file(const char* destination, const char* filepath);
+void cp_file(const char* destination, const char* filepath);
+void get_current_directory(char *buf, size_t size);
+void resolve_absolute_path(char* absolute_path, const char* filename);
 #endif

--- a/main.c
+++ b/main.c
@@ -25,7 +25,7 @@ void block_signals(sigset_t *oldset) {
     sigaddset(&blockset, SIGINT);  // SIGINT (Ctrl+C) 차단
     if (sigprocmask(SIG_BLOCK, &blockset, oldset) == -1) {
         //perror("sigprocmask - block");
-        display_error(menu_win,"sigprocmask - block");
+        display_error("sigprocmask - block");
         exit(EXIT_FAILURE);
     }
 }
@@ -33,7 +33,7 @@ void block_signals(sigset_t *oldset) {
 void unblock_signals(sigset_t *oldset) {
     if (sigprocmask(SIG_SETMASK, oldset, NULL) == -1) {
         //perror("sigprocmask - unblock");
-        display_error(menu_win,"sigprocmask - unblock");
+        display_error("sigprocmask - unblock");
         exit(EXIT_FAILURE);
     }
 }
@@ -117,8 +117,17 @@ int main() {
         // Move 상태 해제 조건
         if (file_flag == 1 && !is_arrow_key && !is_paste_key && ch != 'm') {
             file_flag = 0;
-            mvwchgat(menu_win, 0, 21, 9, A_NORMAL, 1, NULL);  // Move (M) 기본 배경 복원
+            mvwchgat(menu_win, 0, 24, 9, A_NORMAL, 1, NULL);  // Move (M) 기본 배경 복원
             wrefresh(menu_win);
+
+            // 현재 디렉터리 파일 목록을 다시 로드하고 화면 갱신
+            file_count = load_files(files, preview_win);
+            highlight = 0;  // highlight 초기화
+            scroll_offset = 0;  // scrikk_offset 초기화
+            display_files(left_win, files, file_count, highlight, scroll_offset);
+            display_preview(preview_win, files[highlight]);
+            display_path(path_win, preview_win);
+            refresh();
         }
 
         // Delete 상태 해제 조건
@@ -132,6 +141,8 @@ int main() {
             case KEY_UP:
                 if (highlight > 0) highlight--;
                 if (highlight < scroll_offset) scroll_offset--;
+                if (highlight < 0) highlight = 0; // highlight 경계값 체크
+                if (scroll_offset < 0) scroll_offset = 0; // scroll_offset 경계값 체크
                 display_files(left_win, files, file_count, highlight, scroll_offset);
                 display_preview(preview_win, files[highlight]);
                 display_path(path_win, preview_win);
@@ -141,6 +152,7 @@ int main() {
                 if (highlight < file_count - 1) highlight++;
                 if (highlight >= scroll_offset + getmaxy(left_win) - 3) scroll_offset++;
                 display_files(left_win, files, file_count, highlight, scroll_offset);
+                if (highlight >= file_count) highlight = file_count - 1; // highlight 경계값 체크
                 display_preview(preview_win, files[highlight]);
                 display_path(path_win, preview_win);
                 break;
@@ -174,11 +186,13 @@ int main() {
                             display_preview(preview_win, "."); // 현재 디렉터리 내용 표시
                             display_path(path_win, preview_win);
                         } else {    // 디렉터리 이동 실패하면
-                            mvwprintw(preview_win, 1, 1, "Failed to change directory.");
+                            display_error("Failed to change directory.");
+                            //mvwprintw(preview_win, 1, 1, "Failed to change directory.");
                             wrefresh(preview_win);
                         }
                     } else {    //루트 디렉터리면
-                        mvwprintw(preview_win, 1, 1, "Not a directory: %s", files[highlight]);
+                        display_error("Not a directory : %s",files[highlight]);
+                        //mvwprintw(preview_win, 1, 1, "Not a directory: %s", files[highlight]);
                         wrefresh(preview_win);
                     }
                 }
@@ -191,12 +205,26 @@ int main() {
                 filename = files[highlight];
 
                 strcpy(save_filename, filename);
-                resolve_absolute_path(abs_filepath, filename, preview_win);
+                resolve_absolute_path(abs_filepath, filename);
 
                 // Copy 메뉴 배경색 변경
                 mvwchgat(menu_win, 0, 1, 8, A_NORMAL, 7, NULL); // Copy (C) 배경 시안으로 변경
                 wrefresh(menu_win);
                 refresh();
+
+
+                for (int i = 0; i < file_count; i++) {
+                    free(files[i]);
+                }   
+                file_count = load_files(files, preview_win);
+
+
+                highlight = 0;  // 강조 표시 초기화
+                scroll_offset = 0;  // 스크롤 초기화
+                display_files(left_win, files, file_count, highlight, scroll_offset);
+                display_preview(preview_win, files[highlight]); // 미리보기 창 갱신
+
+                
                 break;
 
             case 'd':  // Delete
@@ -204,7 +232,7 @@ int main() {
                 filename = files[highlight];
                  // 시그널 차단
                 block_signals(&oldset);
-                remove_file(filename, preview_win); // 파일 삭제
+                remove_file(filename); // 파일 삭제
                 // 시그널 차단 해제
                 unblock_signals(&oldset);
                 file_count = load_files(files, preview_win);
@@ -227,18 +255,29 @@ int main() {
                 memset(abs_filepath, 0, PATH_MAX);
                 filename = files[highlight];
                 strcpy(save_filename, filename);
-                resolve_absolute_path(abs_filepath, filename, preview_win);
+                resolve_absolute_path(abs_filepath, filename);
 
                 mvwchgat(menu_win, 0, 24, 8, A_NORMAL, 7, NULL); // Move (M) 배경 시안으로 변경
                 wrefresh(menu_win);
                 refresh();
+
+                for (int i = 0; i < file_count; i++) {
+                    free(files[i]);
+                }   
+                file_count = load_files(files, preview_win);
+
+
+                highlight = 0;  // 강조 표시 초기화
+                scroll_offset = 0;  // 스크롤 초기화
+                display_files(left_win, files, file_count, highlight, scroll_offset);
+                display_preview(preview_win, files[highlight]); // 미리보기 창 갱신
                 break;
 
             case 'p':  // Paste
                 if (file_flag != 0) {
                     memset(abs_dirpath, 0, PATH_MAX);
                     memset(destination, 0, PATH_MAX);
-                    get_current_directory(abs_dirpath,PATH_MAX, preview_win);
+                    get_current_directory(abs_dirpath,PATH_MAX);
                     strcat(destination, abs_dirpath);
                     strcat(destination, "/");
                     strcat(destination, save_filename);
@@ -247,14 +286,14 @@ int main() {
                             case 1:
                                 // 시그널 차단
                                 block_signals(&oldset);
-                                move_file(destination, abs_filepath, preview_win); // Move
+                                move_file(destination, abs_filepath); // Move
                                 // 시그널 차단 해제
                                 unblock_signals(&oldset);
                                 break; 
                             case 2:
                                  // 시그널 차단
                                 block_signals(&oldset);
-                                cp_file(destination, abs_filepath, preview_win); // Copy
+                                cp_file(destination, abs_filepath); // Copy
                                 // 시그널 차단 해제
                                 unblock_signals(&oldset);
                                 break; 
@@ -278,7 +317,7 @@ int main() {
 
                 
                 } else {
-                    display_error(menu_win, "No file to paste");  // 에러 메시지 출력
+                    display_error( "No file to paste");  // 에러 메시지 출력
                 
                     break;
                 }
@@ -325,7 +364,7 @@ int main() {
                 struct stat file_stat;
                 if (stat(files[highlight], &file_stat) == 0) { // 파일 상태 확인
                     if (S_ISDIR(file_stat.st_mode)) { // 디렉터리인 경우 Tab 동작 무시
-                        display_error(menu_win,"Error : Cannot open directories with Tab.");
+                        display_error("Error : Cannot open directories with Tab.");
                         //mvwprintw(preview_win, 1, 1, "Error : Cannot open directories with Tab.");
                         wrefresh(preview_win);
                         break;
@@ -337,12 +376,13 @@ int main() {
                         highlight_window(preview_win, 0); // 우측 창 비활성화
                     }
                 } else {
-                    display_error(menu_win,"Error : accwssing file : %s",files[highlight]);
+                    display_error("Error : accwssing file : %s",files[highlight]);
                     //mvwprintw(preview_win, 1, 1, "Error :  accessing file: %s", files[highlight]);
                     wrefresh(preview_win);
                 }
                 break;
         }
+            
             
 
     highlight_window(left_win, 1);


### PR DESCRIPTION
1. display_error에서 argument 중 하나인 menu_win을 없애고, gui.h를 import 했습니다.
2. 파일 작업 처리 함수에 argument로 있던 Preview_win이 필요없어졌으므로 지웠습니다.
3. 그외 display_error()를 활용할 수 있는 코드를 대체했습니다.
4. cp_file에 파일 하나가 copy가 될 때마다 display_err를 호출하셨는데, 디렉터리 복사 시 display_err가 굉장히 많이 발생하게 되므로 지웠습니다. 
5. cp_file에 하위 디렉터리 비교 코드를 간소화했습니다.